### PR TITLE
修改了一些无法打开的项目的状态

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **2. 项目有 3 种状态**          
 
-| 开发中 | 已上线 | 已关闭 |
+| 开发中 | 已上线 | 已关闭或缺乏维护 |
 |--------|--------|--------|
 | :clock8: | :white_check_mark: | :x: |
 
@@ -136,7 +136,7 @@
 ### 2020年2月29号添加
 ---
 #### Roderick Qiu(杭州) - [Github](https://github.com/RoderickQiu), [网站](https://r-q.name/)
-* :white_check_mark: [wnr](https://wnr.scris.top)：跨平台的轻量计时软件，让你更高效、强力地管理作与息 - [更多介绍](https://wnr.scris.top/zh/)
+* :x: [wnr](https://wnr.scris.top)：跨平台的轻量计时软件，让你更高效、强力地管理作与息 - [更多介绍](https://wnr.scris.top/zh/)
 
 ### 2020年2月11号添加
 ---
@@ -189,7 +189,7 @@
 * :white_check_mark: [自考英语查询](https://eng.sxisa.com/)：英语单词查询网站，支持简单的笔记记录 - [更多介绍](https://github.com/imlinhanchao/eng)
 * :white_check_mark: [Code Snippet](https://code-snippet.cn/)：代码片段分享网站，类似 Gist，新增了代码在线运行和网页预览的功能 - [更多介绍](https://github.com/imlinhanchao/code-snippet)
 * :white_check_mark: [Google 翻译 VSCode 扩展](https://marketplace.visualstudio.com/items?itemName=hancel.google-translate)：基于 Google 翻译的 VSCode 扩展 - [更多介绍](https://github.com/imlinhanchao/vsc-google-translate)
-* :white_check_mark: [婚礼邀请函制作工具](http://marry.git.hancel.org/)：快速自定义批量制作婚礼邀请函 - [更多介绍](https://github.com/imlinhanchao/invitation-card-maker)
+* :x: [婚礼邀请函制作工具](http://marry.git.hancel.org/)：快速自定义批量制作婚礼邀请函 - [更多介绍](https://github.com/imlinhanchao/invitation-card-maker)
 * :white_check_mark: [KeyGenius](https://github.com/imlinhanchao/KeyGenius/releases/download/1.0.2/KeyGenius.exe)：用来定时按下某个按键。比如 Ctrl + S，免得忘记保存 - [更多介绍](https://github.com/imlinhanchao/KeyGenius)
 * :clock8: [Librejo 我的书](https://librejo.cn)：一个图书笔记借阅管理的网站 - [更多介绍](https://github.com/imlinhanchao/librejo)
 * :white_check_mark: [Markdown Image](https://marketplace.visualstudio.com/items?itemName=hancel.markdown-image)：VSCode 扩展，直接复制粘贴即可在 Markdown 文件即可插入图片，支持上传到多种图床 - [更多介绍](https://github.com/imlinhanchao/vsc-markdown-image)
@@ -198,7 +198,7 @@
 ### 2019年12月9号添加
 ---
 #### nicejade(ShenZhen) - [Github](https://github.com/nicejade), [博客](https://www.jeffjade.com)
-* :white_check_mark: [Arya - 在线 Markdown 编辑器](https://markdown.lovejade.cn)：一款基于 Vue、Vditor 所构建的在线 Markdown 编辑器 - [更多介绍](https://www.jeffjade.com/2019/05/31/155-arya-markdown-online-editor/)
+* :x: [Arya - 在线 Markdown 编辑器](https://markdown.lovejade.cn)：一款基于 Vue、Vditor 所构建的在线 Markdown 编辑器 - [更多介绍](https://www.jeffjade.com/2019/05/31/155-arya-markdown-online-editor/)
 
 ### 2019年11月27号添加
 ---
@@ -228,7 +228,6 @@
 * :white_check_mark: [足迹中国](https://apps.apple.com/cn/app/id1482250279)：用地图截图记录你去过的中国的省市(上架不久,完善中)
 * :white_check_mark: [假装来电](https://apps.apple.com/cn/app/id1475866564)：设置一定时间后,收到虚假的来电,用于逃离某些场合
 * :white_check_mark: [iStat Widget](https://apps.apple.com/cn/app/id1476638491)：查看硬件信息
-* :white_check_mark: [App Store 全部作品](https://apps.apple.com/us/developer/yiwu-madan-network-technology-co-ltd/id1131521364)
 
 ### 2019年11月6号添加
 ---
@@ -256,7 +255,7 @@
 ### 2019年10月26号添加
 ---
 #### sdmtai(山东) - [Github](https://github.com/faithxie)
-* :white_check_mark: [历史地图](https://sdmtai.github.io/)：中国历史疆域地图
+* :x: [历史地图](https://sdmtai.github.io/)：中国历史疆域地图
 
 ### 2019年10月21号添加
 ---
@@ -270,7 +269,7 @@
 * :white_check_mark: [markdown-resume](https://resume.mdnice.com/)：支持 Markdown 和富文本的在线简历排版工具 - [更多介绍](https://github.com/mdnice/markdown-resume)
 
 #### 痕迹(深圳) - [Github](https://github.com/lijy91), [博客](https://thecode.me)
-* :white_check_mark: [wordway](https://wordway.thecode.me)：由社区驱动的背单词应用 - [更多介绍](https://github.com/wordway/wordway-app/issues/1)
+* :x: [wordway](https://wordway.thecode.me)：由社区驱动的背单词应用 - [更多介绍](https://github.com/wordway/wordway-app/issues/1)
 
 ### 2019年10月18号添加
 ---
@@ -295,7 +294,7 @@
 ### 2019年10月7号添加
 ---
 #### zhshch2002 - [Github](https://github.com/zhshch2002)
-* :white_check_mark: [星文 - Xstar News](https://xstar.news/#/)：一个有理想的~~划水~~独立创作博客聚合网站
+* :x: [星文 - Xstar News](https://xstar.news/#/)：一个有理想的~~划水~~独立创作博客聚合网站
 
 ### 2019年9月30号添加
 ---
@@ -334,13 +333,13 @@
 ### 2019年8月18号添加
 ---
 #### weilaihui(成都) -  [GitHub](https://github.com/weilaihui)
-* :white_check_mark: [GRLib](https://www.grlib.com/)：收藏优质 GitHub 项目 
+* :x: [GRLib](https://www.grlib.com/)：收藏优质 GitHub 项目 
 
 ### 2019年8月11号添加
 ---
 #### Kiddyu(保定) - [Github](https://github.com/kiddyuchina)
 * :white_check_mark: [新趣集](https://xinquji.com)：一个互联网新产品发现社区，36kr next 的替代品  
-* :white_check_mark: [独角兽排行](https://dujiaoshou.io)：全球独角兽企业榜单与招聘
+* :x: [独角兽排行](https://dujiaoshou.io)：全球独角兽企业榜单与招聘
 
 ### 2019年8月2号添加
 ---
@@ -350,7 +349,7 @@
 ### 2019年8月1号添加
 ---
 #### Andy - [Github](https://github.com/ifrontend-xyz)
-* :white_check_mark: [Research](http://www.suiyuanka.com/?q=%E7%8B%AC%E7%AB%8B%E5%BC%80%E5%8F%91%E8%80%85)：快速搜索相关内容
+* :x: [Research](http://www.suiyuanka.com/?q=%E7%8B%AC%E7%AB%8B%E5%BC%80%E5%8F%91%E8%80%85)：快速搜索相关内容
 
 #### fancy - [Github](https://github.com/fanchangyong)
 * :white_check_mark: [橙子简历](https://wonderfulcv.com)：在线简历制作网站-制作简历，告别word排版
@@ -385,12 +384,12 @@
 ### 2019年6月24号添加
 ---
 #### 土豆(北京) - [Github](https://github.com/iphysresearch/)
-* :white_check_mark: [Data Science Challenge / Competition Deadlines](https://iphysresearch.github.io/DataSciComp/)：数据科学赛题汇编+赛题注册倒计时
+* :x: [Data Science Challenge / Competition Deadlines](https://iphysresearch.github.io/DataSciComp/)：数据科学赛题汇编+赛题注册倒计时
 
 ### 2019年6月23号添加
 ---
 #### jiajunhuang(深圳) - [Github](https://github.com/jiajunhuang), [博客](https://jiajunhuang.com/)
-* :white_check_mark: [把Kindle笔记导出成纯文本](https://tools.jiajunhuang.com/)：一键将 Kindle 笔记导出成纯文本，方便编辑成 markdown 等
+* :x: [把Kindle笔记导出成纯文本](https://tools.jiajunhuang.com/)：一键将 Kindle 笔记导出成纯文本，方便编辑成 markdown 等
 
 ### 2019年6月19号添加
 ---
@@ -400,7 +399,7 @@
 ### 2019年6月5号添加
 ---
 #### vulgur - [Github](https://github.com/vulgur), [博客](https://vulgur.github.io)
-* :white_check_mark: [极简翻页时钟（Zen Flip Clock）](https://itunes.apple.com/us/app/zen-flip-clock/id1265404088?l=zh&ls=1&mt=8)：一款免费无广告的极简主义翻页钟&番茄钟 app
+* :x: [极简翻页时钟（Zen Flip Clock）](https://itunes.apple.com/us/app/zen-flip-clock/id1265404088?l=zh&ls=1&mt=8)：一款免费无广告的极简主义翻页钟&番茄钟 app
 
 ### 2019年6月4号添加
 ---
@@ -444,7 +443,7 @@
 ### 2019年4月29号添加
 ---
 #### YuzhouZhang(杭州) - [Github](https://github.com/YuzhouZhang)
-* :white_check_mark: [闪电词典](https://play.google.com/store/apps/details?id=com.wingtech.quicklearnersdictionary)：取词最快的英英词典！
+* :x: [闪电词典](https://play.google.com/store/apps/details?id=com.wingtech.quicklearnersdictionary)：取词最快的英英词典！
 
 ### 2019年4月28号添加
 ---
@@ -459,7 +458,7 @@
 ### 2019年4月26号添加
 ---
 #### a188037445 - [Github](https://github.com/a188037445)
-* :white_check_mark: [Hash Calculator](https://github.com/a188037445/Hash-Calculator)：极速哈希计算器
+* :x: [Hash Calculator](https://github.com/a188037445/Hash-Calculator)：极速哈希计算器
 
 ### 2019年4月22号添加
 ---


### PR DESCRIPTION
普通版页面供非程序员使用，所以我在没开梯子的情况下检查了所有项目的运行情况，部分项目已经打不开链接或者关闭了。
仅检查了2019.4.11以后的链接，我想暂时先pull一下